### PR TITLE
Fix carousel button event handling

### DIFF
--- a/script5.js
+++ b/script5.js
@@ -66,7 +66,8 @@
 const buttons = document.querySelectorAll('.carusel_button')
 function changeBtnColor(event){
     buttons.forEach(elem => elem.classList.remove('btnColorActive'))
-    event.target.classList.add('btnColorActive')
+    // use currentTarget to ensure the button itself receives the class
+    event.currentTarget.classList.add('btnColorActive')
 }
 buttons.forEach((elem)=> elem.addEventListener('click', changeBtnColor))
 


### PR DESCRIPTION
## Summary
- make carousel button event handler use `currentTarget`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ae467dd748321a79b5b93873b8d63